### PR TITLE
chore: update exports structure and version in deno.json

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,10 @@
   "name": "@zsqk/crc64",
   "version": "0.1.3",
   "license": "MIT",
-  "exports": "./build/release.js",
+  "exports": {
+    "./js": "./build/release.js",
+    "./wasm": "./build/release.wasm"
+  },
   "tasks": {
     "asbuild:debug": "asc assembly/crc64.ts --target debug",
     "asbuild:release": "asc assembly/crc64.ts --target release",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@zsqk/crc64",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "exports": {
     "./js": "./build/release.js",


### PR DESCRIPTION
Revise the exports structure to support both JavaScript and WebAssembly, and update the version to 0.1.4.